### PR TITLE
Added metadata tags to header

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,13 +3,22 @@
 
 <head>
 	<meta charset="UTF-8">
-	<meta name="keywords" content="T-Huis, UNIX, public access server">
+	<meta name="language" content="NL">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="distribution" content="global">
+	<link rel="canonical" href="http://users.t-huis.lgbt">
+	<link rel="icon" href="favicon.ico" type="image/x-icon">
+
+	<title>T-Huis Public Access Server</title>
 	<meta name="author" content="T-Huis">
 	<meta name="copyright" content="T-Huis">
-	<meta name="language" content="NL">
-	<meta name="distribution" content="global">
-	<meta name="description" content="T-Huis UNIX public access server">
-	<title>T-Huis Public Access Server</title>
+	<meta name="title" content="T-Huis Public Access Server">
+	<meta name="keywords" content="T-Huis, UNIX, public access server, PAS, U-PAST, UPAST">
+	<meta name="description" content="T-Huis UNIX Public Access Server, ook wel U-PAST genoemd,
+      is een initiatief van staff en leden van de T-Huis Discord server, de eerste, grootste en
+      gezelligste transgender Discord server van Nederland. Als je hier interesse in hebt, kan
+      je je aanmelden via T-huis.xyz!">
+
 	<style>
 		* {
 			margin: 0px 0px 0px 0px;

--- a/src/index.html
+++ b/src/index.html
@@ -14,10 +14,12 @@
 	<meta name="copyright" content="T-Huis">
 	<meta name="title" content="T-Huis Public Access Server">
 	<meta name="keywords" content="T-Huis, UNIX, public access server, PAS, U-PAST, UPAST">
-	<meta name="description" content="T-Huis UNIX Public Access Server, ook wel U-PAST genoemd,
-      is een initiatief van staff en leden van de T-Huis Discord server, de eerste, grootste en
-      gezelligste transgender Discord server van Nederland. Als je hier interesse in hebt, kan
-      je je aanmelden via T-huis.xyz!">
+	<!--
+      Following description can't be shorted by splitting it into multiple lanes! Doing that will
+      result in new lines on applications such as Discord and possibly also others.
+     -->
+	<meta name="description"
+		content="T-Huis UNIX Public Access Server, ook wel U-PAST genoemd, is een initiatief van staff en leden van de T-Huis Discord server, de eerste, grootste en gezelligste transgender Discord server van Nederland. Als je hier interesse in hebt, kan je je aanmelden via T-huis.xyz!">
 
 	<style>
 		* {


### PR DESCRIPTION
Using this the site will be able to be viewed with a bit more of an informative description on. The Discord preview being a bit broken in the screenshot but fixed in the latest commit, just don't know how long untill there cache resets.

![Screenshot 2023-04-19 at 18-34-31 Meta Tags — Preview Edit and Generate](https://user-images.githubusercontent.com/18311389/233144105-cb2d60e2-ef1b-4713-b0db-30f23fb61ff9.png)
![Screenshot_20230419_184845](https://user-images.githubusercontent.com/18311389/233144946-448be9f4-f939-4732-b8c4-bfb0443b58ad.png)


This is compared to the old state below.
![Screenshot 2023-04-19 at 18-46-53 Meta Tags — Preview Edit and Generate](https://user-images.githubusercontent.com/18311389/233144569-f136843a-a529-4307-a6f2-964950f05be3.png)
![Screenshot_20230419_184801](https://user-images.githubusercontent.com/18311389/233144823-a42ad773-6be4-4571-bd15-39ae3d7e6243.png)


